### PR TITLE
Add support for YAML manifests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/lyraproj/puppet-workflow
 require (
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e
 	github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a
-	github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc
-	github.com/lyraproj/puppet-evaluator v0.0.0-20190121224504-9cbd778da25e
+	github.com/lyraproj/issue v0.0.0-20190122215520-5efbea1d1edb
+	github.com/lyraproj/puppet-evaluator v0.0.0-20190123103958-578b5068e92c
 	github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d
 	github.com/lyraproj/servicesdk v0.0.0-20190121225535-bdf437187a7c
 )

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,12 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820 h1:fmQMG2XAvAhT5gt9PxXhY3+2iHJPBM1Y073MuNTZShM=
 github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20181204205859-7ed1f9741f4a/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
-github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc h1:OD9e7aHLSyJcrwG1R/8JsDVIWevC7aJH+Yd09q/8e2I=
 github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190121224504-9cbd778da25e h1:DZJzTl39sOcjV0F8cmjBXsDm1SpMgqr7VfunUm5yy9I=
+github.com/lyraproj/issue v0.0.0-20190122215520-5efbea1d1edb h1:R3ukQUNWJTypfOAZwyJ5kcIyWjbm8KZnpxLaH29HWbw=
+github.com/lyraproj/issue v0.0.0-20190122215520-5efbea1d1edb/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/puppet-evaluator v0.0.0-20190121224504-9cbd778da25e/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190123103958-578b5068e92c h1:B+eWVKqsxIMw3TqDqxYexYc8rdZSZjKjyiliKaCYMq8=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190123103958-578b5068e92c/go.mod h1:Z0RDGXCJwnba8AZttdopo2/JzUiGsN7CECdUqZPR3wU=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d h1:iDn6XlJAiA+BuwG6L8xsCapPpc7jz24SGj9z7NQA1sg=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d/go.mod h1:8va5g/XEw+jP9jnwEXPmanUy/hD9+6iggnaioihPLP0=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
@@ -38,6 +40,7 @@ golang.org/x/net v0.0.0-20190119204137-ed066c81e75e h1:MDa3fSUp6MdYHouVmCCNz/zaH
 golang.org/x/net v0.0.0-20190119204137-ed066c81e75e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522 h1:Ve1ORMCxvRmSXBwJK+t3Oy+V2vRW2OetUQBq4rJIkZE=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
@@ -49,4 +52,7 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.18.0 h1:IZl7mfBGfbhYx2p2rKRtYgDFw6SBz+kclmxYrCksPPA=
 google.golang.org/grpc v1.18.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/puppet/activity.go
+++ b/puppet/activity.go
@@ -271,7 +271,7 @@ func (a *puppetActivity) getAPI(c eval.Context, input []eval.Parameter) eval.Pup
 		missing = `delete`
 	}
 	if missing != `` {
-		panic(c.Error(block, WF_MISSING_REQUIRED_FUNCION, issue.H{`function`: missing}))
+		panic(c.Error(block, WF_MISSING_REQUIRED_FUNCTION, issue.H{`function`: missing}))
 	}
 	if update == nil {
 		return NewCRD(a.Name(), create, read, remove)
@@ -344,7 +344,7 @@ func (a *puppetActivity) getResourceType(c eval.Context) eval.ObjectType {
 				panic(eval.Error(WF_FIELD_TYPE_MISMATCH, issue.H{`field`: `definition`, `expected`: `Variant[String,ObjectType]`, `actual`: tv}))
 			}
 		} else {
-			ts := a.getTypespace()
+			ts := a.getTypeSpace()
 			if ts != `` {
 				n = ts + `::` + wfapi.LeafName(n)
 			}
@@ -360,12 +360,12 @@ func (a *puppetActivity) getResourceType(c eval.Context) eval.ObjectType {
 	panic(eval.Error(eval.EVAL_UNRESOLVED_TYPE, issue.H{`typeString`: tn.Name()}))
 }
 
-func (a *puppetActivity) getTypespace() string {
+func (a *puppetActivity) getTypeSpace() string {
 	if ts, ok := a.getStringProperty(`typespace`); ok {
 		return ts
 	}
 	if a.parent != nil {
-		return a.parent.getTypespace()
+		return a.parent.getTypeSpace()
 	}
 	return ``
 }

--- a/puppet/crud.go
+++ b/puppet/crud.go
@@ -78,12 +78,12 @@ func (c *do) InitHash() eval.OrderedMap {
 	return types.SingletonHash2(`name`, types.WrapString(c.name))
 }
 
-func (d *do) Call(c eval.Context, method eval.ObjFunc, args []eval.Value, block eval.Lambda) (result eval.Value, ok bool) {
+func (c *do) Call(ctx eval.Context, method eval.ObjFunc, args []eval.Value, block eval.Lambda) (result eval.Value, ok bool) {
 	if method.Name() != `do` {
 		return nil, false
 	}
 	if block != nil {
-		panic(errors.NewArgumentsError(d.name, `nested lambdas are not supported`))
+		panic(errors.NewArgumentsError(c.name, `nested lambdas are not supported`))
 	}
 
 	defer func() {
@@ -98,7 +98,7 @@ func (d *do) Call(c eval.Context, method eval.ObjFunc, args []eval.Value, block 
 			}
 		}
 	}()
-	result = impl.CallBlock(c, d.name, d.parameters, method.Type().(*types.CallableType), d.body, args)
+	result = impl.CallBlock(ctx, c.name, c.parameters, method.Type().(*types.CallableType), c.body, args)
 	return
 }
 

--- a/puppet/functions/registerhandler.go
+++ b/puppet/functions/registerhandler.go
@@ -1,8 +1,8 @@
 package functions
 
 import (
-	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/issue/issue"
+	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/servicesdk/service"
 
 	// Ensure initialization of needed packages

--- a/puppet/issues.go
+++ b/puppet/issues.go
@@ -3,12 +3,12 @@ package puppet
 import "github.com/lyraproj/issue/issue"
 
 const (
-	WF_FIELD_TYPE_MISMATCH          = `WF_FIELD_TYPE_MISMATCH`
-	WF_ELEMENT_NOT_PARAMETER        = `WF_ELEMENT_NOT_PARAMETER`
-	WF_NO_DEFINITION                = `WF_NO_DEFINITION`
-	WF_NOT_ACTIVITY                 = `WF_NOT_ACTIVITY`
-	WF_INVALID_FUNCTION             = `WF_INVALID_FUNCTION`
-	WF_MISSING_REQUIRED_FUNCION     = `WF_MISSING_REQUIRED_FUNCION`
+	WF_FIELD_TYPE_MISMATCH       = `WF_FIELD_TYPE_MISMATCH`
+	WF_ELEMENT_NOT_PARAMETER     = `WF_ELEMENT_NOT_PARAMETER`
+	WF_NO_DEFINITION             = `WF_NO_DEFINITION`
+	WF_NOT_ACTIVITY              = `WF_NOT_ACTIVITY`
+	WF_INVALID_FUNCTION          = `WF_INVALID_FUNCTION`
+	WF_MISSING_REQUIRED_FUNCTION = `WF_MISSING_REQUIRED_FUNCTION`
 )
 
 func init() {
@@ -16,7 +16,7 @@ func init() {
 	issue.Hard(WF_ELEMENT_NOT_PARAMETER, `expected activity %{field} element to be a Parameter, got %{type}`)
 	issue.Hard(WF_NO_DEFINITION, `expected activity to contain a definition block`)
 	issue.Hard(WF_INVALID_FUNCTION, `invalid function '%{function}'. Expected one of 'create', 'read', 'update', or 'delete'`)
-	issue.Hard(WF_MISSING_REQUIRED_FUNCION, `missing required '%{function}'`)
-	issue.Hard2(WF_NOT_ACTIVITY, `block may only contain workflow activites. %{actual} is not supported here`,
+	issue.Hard(WF_MISSING_REQUIRED_FUNCTION, `missing required '%{function}'`)
+	issue.Hard2(WF_NOT_ACTIVITY, `block may only contain workflow activities. %{actual} is not supported here`,
 		issue.HF{`actual`: issue.A_anUc})
 }

--- a/yaml/activity.go
+++ b/yaml/activity.go
@@ -1,0 +1,449 @@
+package yaml
+
+import (
+	"github.com/lyraproj/issue/issue"
+	"github.com/lyraproj/puppet-evaluator/eval"
+	"github.com/lyraproj/puppet-evaluator/impl"
+	"github.com/lyraproj/puppet-evaluator/types"
+	"github.com/lyraproj/puppet-evaluator/yaml"
+	"github.com/lyraproj/servicesdk/wfapi"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+type activity struct {
+	name     string
+	parent   *activity
+	hash     eval.OrderedMap
+	rt       eval.ObjectType
+	activity wfapi.Activity
+}
+
+const kindWorkflow = 1
+const kindResource = 2
+
+func CreateActivity(c eval.Context, file string, content []byte) wfapi.Activity {
+	c.StackPush(issue.NewLocation(file, 0, 0))
+	defer c.StackPop()
+
+	v := yaml.Unmarshal(c, content)
+	h, ok := v.(eval.OrderedMap)
+	if !(ok && h.Len() == 1) {
+		panic(eval.Error(WF_NOT_ONE_DEFINITION, issue.NO_ARGS))
+	}
+
+	var name string
+	var def eval.OrderedMap
+	h.EachPair(func(k, v eval.Value) {
+		if n, ok := k.(eval.StringValue); ok {
+			name = n.String()
+		}
+		if m, ok := v.(eval.OrderedMap); ok {
+			def = m
+		}
+	})
+	if name == `` || def == nil {
+		panic(eval.Error(WF_NOT_ACTIVITY, issue.NO_ARGS))
+	}
+
+	a := newActivity(name, nil, def)
+	switch a.activityKind() {
+	case kindWorkflow:
+		return wfapi.NewWorkflow(c, func(wb wfapi.WorkflowBuilder) {
+			a.buildWorkflow(wb)
+		})
+	default:
+		return wfapi.NewResource(c, func(wb wfapi.ResourceBuilder) {
+			a.buildResource(wb)
+		})
+	}
+}
+
+func newActivity(name string, parent *activity, ex eval.OrderedMap) *activity {
+	ca := &activity{parent: parent, hash: ex}
+	sgs := strings.Split(name, `::`)
+	ca.name = sgs[len(sgs)-1]
+	return ca
+}
+
+func (a *activity) activityKind() int {
+	m := a.hash
+	if m.IncludesKey2(`activities`) {
+		return kindWorkflow
+	}
+	if m.IncludesKey2(`state`) {
+		return kindResource
+	}
+	panic(eval.Error(WF_NOT_ACTIVITY, issue.NO_ARGS))
+}
+
+func (a *activity) Activity() wfapi.Activity {
+	return a.activity
+}
+
+func (a *activity) Name() string {
+	return a.name
+}
+
+func (a *activity) Label() string {
+	return a.Style() + " " + a.Name()
+}
+
+func (a *activity) buildActivity(builder wfapi.Builder) {
+	builder.Name(a.Name())
+	builder.When(a.getWhen())
+	builder.Input(a.extractParameters(builder.Context(), a.hash, `input`, false)...)
+	builder.Output(a.extractParameters(builder.Context(), a.hash, `output`, true)...)
+}
+
+func (a *activity) buildResource(builder wfapi.ResourceBuilder) {
+	c := builder.Context()
+
+	builder.Name(a.Name())
+	builder.When(a.getWhen())
+
+	st, input := a.getState(c, a.extractParameters(builder.Context(), a.hash, `input`, false))
+	builder.Input(input...)
+	builder.Output(a.extractParameters(builder.Context(), a.hash, `output`, true)...)
+	builder.State(&state{ctx: c, stateType: a.getResourceType(c), unresolvedState: st})
+}
+
+func (a *activity) buildStateless(builder wfapi.StatelessBuilder) {
+	a.buildActivity(builder)
+}
+
+func (a *activity) buildWorkflow(builder wfapi.WorkflowBuilder) {
+	a.buildActivity(builder)
+	de, ok := a.hash.Get4(`activities`)
+	if !ok {
+		return
+	}
+
+	block, ok := de.(eval.OrderedMap)
+	if !ok {
+		panic(eval.Error(WF_FIELD_TYPE_MISMATCH, issue.H{`activity`: a, `field`: `definition`, `expected`: `CodeBlock`, `actual`: de}))
+	}
+
+	// Block should only contain activity expressions or something is wrong.
+	block.EachPair(func(k, v eval.Value) {
+		if as, ok := v.(eval.OrderedMap); ok {
+			a.workflowActivity(builder, k.String(), as)
+		} else {
+			panic(eval.Error(WF_NOT_ACTIVITY, issue.H{`actual`: as}))
+		}
+	})
+}
+
+func (a *activity) workflowActivity(builder wfapi.WorkflowBuilder, name string, as eval.OrderedMap) {
+	ac := newActivity(name, a, as)
+	if _, ok := ac.hash.Get4(`iteration`); ok {
+		builder.Iterator(ac.buildIterator)
+	} else {
+		switch ac.activityKind() {
+		case kindWorkflow:
+			builder.Workflow(ac.buildWorkflow)
+		default:
+			builder.Resource(ac.buildResource)
+		}
+	}
+}
+
+func (a *activity) Style() string {
+	switch a.activityKind() {
+	case kindWorkflow:
+		return `workflow`
+	default:
+		return `resource`
+	}
+}
+
+func (a *activity) inferInput() []eval.Parameter {
+	// TODO:
+	return eval.NoParameters
+}
+
+func (a *activity) inferOutput() []eval.Parameter {
+	// TODO:
+	return eval.NoParameters
+}
+
+func (a *activity) buildIterator(builder wfapi.IteratorBuilder) {
+	v, _ := a.hash.Get4(`iteration`)
+	iteratorDef, ok := v.(*types.HashValue)
+	if !ok {
+		panic(eval.Error(WF_FIELD_TYPE_MISMATCH, issue.H{`activity`: a, `field`: `iteration`, `expected`: `Hash`, `actual`: v.PType()}))
+	}
+
+	v = iteratorDef.Get5(`function`, eval.UNDEF)
+	style, ok := v.(eval.StringValue)
+	if !ok {
+		panic(eval.Error(WF_FIELD_TYPE_MISMATCH, issue.H{`activity`: a, `field`: `iteration.style`, `expected`: `String`, `actual`: v}))
+	}
+	if name, ok := iteratorDef.Get4(`name`); ok {
+		builder.Name(name.String())
+	}
+	builder.Style(wfapi.NewIterationStyle(style.String()))
+	builder.Over(a.extractParameters(builder.Context(), iteratorDef, `over`, false)...)
+	builder.Variables(a.extractParameters(builder.Context(), iteratorDef, `vars`, false)...)
+
+	switch a.activityKind() {
+	case kindWorkflow:
+		builder.Workflow(a.buildWorkflow)
+	default:
+		builder.Resource(a.buildResource)
+	}
+}
+
+func (a *activity) getWhen() string {
+	if when, ok := a.getStringProperty(a.hash, `when`); ok {
+		return when
+	}
+	return ``
+}
+
+func (a *activity) extractParameters(c eval.Context, props eval.OrderedMap, field string, isOutput bool) []eval.Parameter {
+	if props == nil {
+		return []eval.Parameter{}
+	}
+
+	v, ok := props.Get4(field)
+	if !ok {
+		return []eval.Parameter{}
+	}
+
+	if ph, ok := v.(eval.OrderedMap); ok {
+		params := make([]eval.Parameter, 0, ph.Len())
+		ph.EachPair(func(k, v eval.Value) {
+			var p eval.Parameter
+			if isOutput {
+				p = a.makeOutputParameter(c, field, k, v)
+			} else {
+				p = a.makeInputParameter(c, field, k, v)
+			}
+			params = append(params, p)
+		})
+		return params
+	}
+
+	if _, ok := v.(eval.StringValue); ok {
+		// Allow single name as a convenience
+		v = types.WrapValues([]eval.Value{v})
+	}
+
+	if pa, ok := v.(*types.ArrayValue); ok {
+		// List of names.
+		params := make([]eval.Parameter, pa.Len())
+		pa.EachWithIndex(func(e eval.Value, i int) {
+			if ne, ok := e.(eval.StringValue); ok {
+				n := ne.String()
+				if isOutput && a.activityKind() == kindResource {
+					// Names must match attribute names
+					params[i] = impl.NewParameter(n, a.attributeType(c, n), nil, false)
+				} else {
+					params[i] = impl.NewParameter(n, types.DefaultAnyType(), nil, false)
+				}
+			} else {
+				panic(eval.Error(WF_BAD_PARAMETER, issue.H{`activity`: a, `name`: e, `parameter_type`: field}))
+			}
+		})
+		return params
+	}
+	panic(eval.Error(WF_FIELD_TYPE_MISMATCH, issue.H{`activity`: a, `field`: field, `expected`: `Hash`, `actual`: v.PType()}))
+}
+
+func (a *activity) makeInputParameter(c eval.Context, field string, k, v eval.Value) (param eval.Parameter) {
+	if n, ok := k.(eval.StringValue); ok {
+		name := n.String()
+		switch v.(type) {
+		case eval.Parameter:
+			param = v.(eval.Parameter)
+		case eval.StringValue:
+			param = impl.NewParameter(name, c.ParseType2(v.String()), nil, false)
+		case eval.OrderedMap:
+			m := v.(eval.OrderedMap)
+			tn, ok := a.getStringProperty(m, `type`)
+			if !ok {
+				break
+			}
+			var val eval.Value
+			tp := c.ParseType2(tn)
+			if lu, ok := m.Get4(`lookup`); ok {
+				var args []eval.Value
+				if a, ok := lu.(*types.ArrayValue); ok {
+					args = a.AppendTo(make([]eval.Value, 0, a.Len()))
+				} else {
+					args = []eval.Value{lu}
+				}
+				val = types.NewDeferred(`lookup`, args...)
+			} else {
+				val = m.Get5(`value`, nil)
+			}
+			param = impl.NewParameter(name, tp, val, false)
+		}
+	}
+	if param == nil {
+		panic(eval.Error(WF_BAD_PARAMETER, issue.H{
+			`activity`: a, `name`: k, `parameter_type`: `input`}))
+	}
+	return
+}
+
+var varNamePattern = regexp.MustCompile(`\A[a-z]\w*(?:\.[a-z]\w*)*\z`)
+
+func (a *activity) makeOutputParameter(c eval.Context, field string, k, v eval.Value) (param eval.Parameter) {
+	// TODO: Iterator output etc.
+	if n, ok := k.(eval.StringValue); ok {
+		name := n.String()
+		switch v.(type) {
+		case eval.Parameter:
+			param = v.(eval.Parameter)
+		case eval.StringValue:
+			s := v.String()
+			if len(s) > 0 && unicode.IsUpper(rune(s[0])) {
+				if a.activityKind() == kindWorkflow {
+					param = impl.NewParameter(name, c.ParseType2(s), nil, false)
+				}
+			} else if varNamePattern.MatchString(s) {
+				if a.activityKind() == kindResource {
+					// Alias declaration
+					param = impl.NewParameter(name, a.attributeType(c, s), v, false)
+				}
+			}
+		case eval.List:
+			if a.activityKind() == kindResource {
+				vl := v.(eval.List)
+				ts := make([]eval.Type, 0, vl.Len())
+				if v.(eval.List).All(func(e eval.Value) bool {
+					if sv, ok := e.(eval.StringValue); ok {
+						s := sv.String()
+						if varNamePattern.MatchString(s) {
+							ts = append(ts, a.attributeType(c, s))
+							return true
+						}
+					}
+					return false
+				}) {
+					param = impl.NewParameter(name, types.NewTupleType(ts, nil), v, false)
+				}
+			}
+		}
+	}
+	if param == nil {
+		panic(eval.Error(WF_BAD_PARAMETER, issue.H{
+			`activity`: a, `name`: k, `parameter_type`: `output`}))
+	}
+	return
+}
+
+func (a *activity) attributeType(c eval.Context, name string) eval.Type {
+	tp := a.getResourceType(c)
+	if m, ok := tp.Member(name); ok {
+		if a, ok := m.(eval.Attribute); ok {
+			return a.Type()
+		}
+	}
+	panic(eval.Error(eval.EVAL_ATTRIBUTE_NOT_FOUND, issue.H{`type`: tp, `name`: name}))
+}
+
+func (a *activity) getState(c eval.Context, input []eval.Parameter) (eval.OrderedMap, []eval.Parameter) {
+	de, ok := a.hash.Get4(`state`)
+	if !ok {
+		return eval.EMPTY_MAP, []eval.Parameter{}
+	}
+
+	if hash, ok := de.(eval.OrderedMap); ok {
+		// Ensure that hash conforms to init of type with respect to attribute names
+		// and transform all variable references to Deferred expressions
+		es := make([]*types.HashEntry, 0, hash.Len())
+		if hash.AllPairs(func(k, v eval.Value) bool {
+			if sv, ok := k.(eval.StringValue); ok {
+				s := sv.String()
+				if varNamePattern.MatchString(s) {
+					at := a.attributeType(c, s)
+					if vs, ok := v.(eval.StringValue); ok {
+						s := vs.String()
+						if len(s) > 1 && s[0] == '$' {
+							vn := s[1:]
+							if varNamePattern.MatchString(vn) {
+								// Add to input unless it's there already
+								found := false
+								for _, ip := range input {
+									if ip.Name() == vn {
+										found = true
+										break
+									}
+								}
+								if !found {
+									input = append(input, impl.NewParameter(vn, at, nil, false))
+								}
+								v = types.NewDeferred(s)
+							}
+						}
+					}
+					es = append(es, types.WrapHashEntry(k, v))
+					return true
+				}
+			}
+			return false
+		}) {
+			return types.WrapHash(es), input
+		}
+	}
+	panic(eval.Error(WF_FIELD_TYPE_MISMATCH, issue.H{`activity`: a, `field`: `definition`, `expected`: `Hash`, `actual`: de}))
+}
+
+func (a *activity) getResourceType(c eval.Context) eval.ObjectType {
+	if a.rt != nil {
+		return a.rt
+	}
+	n := a.Name()
+	if tv, ok := a.hash.Get4(`type`); ok {
+		if t, ok := tv.(eval.ObjectType); ok {
+			a.rt = t
+			return t
+		}
+		if s, ok := tv.(eval.StringValue); ok {
+			n = s.String()
+		} else {
+			panic(eval.Error(WF_FIELD_TYPE_MISMATCH, issue.H{`activity`: a, `field`: `definition`, `expected`: `Variant[String,ObjectType]`, `actual`: tv}))
+		}
+	} else {
+		ts := a.getTypespace()
+		if ts != `` {
+			n = ts + `::` + wfapi.LeafName(n)
+		}
+	}
+
+	tn := eval.NewTypedName(eval.NsType, n)
+	if t, ok := eval.Load(c, tn); ok {
+		if pt, ok := t.(eval.ObjectType); ok {
+			a.rt = pt
+			return pt
+		}
+		panic(eval.Error(WF_FIELD_TYPE_MISMATCH, issue.H{`activity`: a, `field`: `definition`, `expected`: `ObjectType`, `actual`: t}))
+	}
+	panic(eval.Error(eval.EVAL_UNRESOLVED_TYPE, issue.H{`typeString`: tn.Name()}))
+}
+
+func (a *activity) getTypespace() string {
+	if ts, ok := a.getStringProperty(a.hash, `typespace`); ok {
+		return ts
+	}
+	if a.parent != nil {
+		return a.parent.getTypespace()
+	}
+	return ``
+}
+
+func (a *activity) getStringProperty(properties eval.OrderedMap, field string) (string, bool) {
+	v, ok := properties.Get4(field)
+	if !ok {
+		return ``, false
+	}
+
+	if s, ok := v.(eval.StringValue); ok {
+		return s.String(), true
+	}
+	panic(eval.Error(WF_FIELD_TYPE_MISMATCH, issue.H{`activity`: a, `field`: field, `expected`: `String`, `actual`: v.PType()}))
+}

--- a/yaml/activity_test.go
+++ b/yaml/activity_test.go
@@ -1,0 +1,284 @@
+package yaml_test
+
+import (
+	"fmt"
+	"github.com/lyraproj/puppet-evaluator/eval"
+	"github.com/lyraproj/puppet-workflow/yaml"
+	"github.com/lyraproj/servicesdk/service"
+	"io/ioutil"
+	"os"
+
+	// Ensure Pcore and lookup are initialized
+	_ "github.com/lyraproj/puppet-evaluator/pcore"
+	_ "github.com/lyraproj/servicesdk/wf"
+)
+
+func ExampleActivity() {
+	eval.Puppet.Do(func(ctx eval.Context) {
+		typesFile := "testdata/types.pp"
+		content, err := ioutil.ReadFile(typesFile)
+		if err != nil {
+			panic(err.Error())
+		}
+		ast := ctx.ParseAndValidate(typesFile, string(content), false)
+		ctx.AddDefinitions(ast)
+		_, err = eval.TopEvaluate(ctx, ast)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		workflowFile := "testdata/attach.yaml"
+		content, err = ioutil.ReadFile(workflowFile)
+		if err != nil {
+			panic(err.Error())
+		}
+		a := yaml.CreateActivity(ctx, workflowFile, content)
+
+		sb := service.NewServerBuilder(ctx, `Yaml::Test`)
+		sb.RegisterStateConverter(yaml.ResolveState)
+		sb.RegisterActivity(a)
+		sv := sb.Server()
+		_, defs := sv.Metadata(ctx)
+
+		wf := defs[0]
+		wf.ToString(os.Stdout, eval.PRETTY, nil)
+		fmt.Println()
+
+		st := sv.State(ctx, `attach::vpc`, eval.Wrap(ctx, map[string]interface{}{
+			`region`: `us-west`,
+			`tags`:   map[string]string{`a`: `av`, `b`: `bv`}}).(eval.OrderedMap))
+		st.ToString(os.Stdout, eval.PRETTY, nil)
+		fmt.Println()
+	})
+
+	// Output:
+	// Service::Definition(
+	//   'identifier' => TypedName(
+	//     'namespace' => 'definition',
+	//     'name' => 'attach'
+	//   ),
+	//   'serviceId' => TypedName(
+	//     'namespace' => 'service',
+	//     'name' => 'Yaml::Test'
+	//   ),
+	//   'properties' => {
+	//     'input' => [
+	//       Parameter(
+	//         'name' => 'region',
+	//         'type' => String,
+	//         'value' => Deferred(
+	//           'name' => 'lookup',
+	//           'arguments' => ['aws.region']
+	//         )
+	//       ),
+	//       Parameter(
+	//         'name' => 'tags',
+	//         'type' => Hash[String, String],
+	//         'value' => Deferred(
+	//           'name' => 'lookup',
+	//           'arguments' => ['aws.tags']
+	//         )
+	//       ),
+	//       Parameter(
+	//         'name' => 'key_name',
+	//         'type' => String,
+	//         'value' => Deferred(
+	//           'name' => 'lookup',
+	//           'arguments' => ['aws.keyname']
+	//         )
+	//       ),
+	//       Parameter(
+	//         'name' => 'ec2_cnt',
+	//         'type' => Integer,
+	//         'value' => Deferred(
+	//           'name' => 'lookup',
+	//           'arguments' => ['aws.instance.count']
+	//         )
+	//       )],
+	//     'output' => [
+	//       Parameter(
+	//         'name' => 'vpc_id',
+	//         'type' => String
+	//       ),
+	//       Parameter(
+	//         'name' => 'subnet_id',
+	//         'type' => String
+	//       ),
+	//       Parameter(
+	//         'name' => 'internet_gateway_id',
+	//         'type' => String
+	//       ),
+	//       Parameter(
+	//         'name' => 'nodes',
+	//         'type' => Hash[String, Struct[{'public_ip' => String, 'private_ip' => String}]]
+	//       )],
+	//     'activities' => [
+	//       Service::Definition(
+	//         'identifier' => TypedName(
+	//           'namespace' => 'definition',
+	//           'name' => 'attach::vpc'
+	//         ),
+	//         'serviceId' => TypedName(
+	//           'namespace' => 'service',
+	//           'name' => 'Yaml::Test'
+	//         ),
+	//         'properties' => {
+	//           'input' => [
+	//             Parameter(
+	//               'name' => 'region',
+	//               'type' => String
+	//             ),
+	//             Parameter(
+	//               'name' => 'tags',
+	//               'type' => Hash[String, String]
+	//             )],
+	//           'output' => [
+	//             Parameter(
+	//               'name' => 'vpc_id',
+	//               'type' => Optional[String]
+	//             )],
+	//           'resource_type' => Lyra::Aws::Vpc,
+	//           'style' => 'resource'
+	//         }
+	//       ),
+	//       Service::Definition(
+	//         'identifier' => TypedName(
+	//           'namespace' => 'definition',
+	//           'name' => 'attach::subnet'
+	//         ),
+	//         'serviceId' => TypedName(
+	//           'namespace' => 'service',
+	//           'name' => 'Yaml::Test'
+	//         ),
+	//         'properties' => {
+	//           'input' => [
+	//             Parameter(
+	//               'name' => 'region',
+	//               'type' => String
+	//             ),
+	//             Parameter(
+	//               'name' => 'vpc_id',
+	//               'type' => String
+	//             ),
+	//             Parameter(
+	//               'name' => 'tags',
+	//               'type' => Hash[String, String]
+	//             )],
+	//           'output' => [
+	//             Parameter(
+	//               'name' => 'subnet_id',
+	//               'type' => Optional[String]
+	//             )],
+	//           'resource_type' => Lyra::Aws::Subnet,
+	//           'style' => 'resource'
+	//         }
+	//       ),
+	//       Service::Definition(
+	//         'identifier' => TypedName(
+	//           'namespace' => 'definition',
+	//           'name' => 'attach::nodes'
+	//         ),
+	//         'serviceId' => TypedName(
+	//           'namespace' => 'service',
+	//           'name' => 'Yaml::Test'
+	//         ),
+	//         'properties' => {
+	//           'iteration_style' => 'times',
+	//           'over' => [
+	//             Parameter(
+	//               'name' => 'ec2_cnt',
+	//               'type' => Any
+	//             )],
+	//           'variables' => [
+	//             Parameter(
+	//               'name' => 'i',
+	//               'type' => Any
+	//             )],
+	//           'producer' => Service::Definition(
+	//             'identifier' => TypedName(
+	//               'namespace' => 'definition',
+	//               'name' => 'attach::instance'
+	//             ),
+	//             'serviceId' => TypedName(
+	//               'namespace' => 'service',
+	//               'name' => 'Yaml::Test'
+	//             ),
+	//             'properties' => {
+	//               'input' => [
+	//                 Parameter(
+	//                   'name' => 'region',
+	//                   'type' => String
+	//                 ),
+	//                 Parameter(
+	//                   'name' => 'i',
+	//                   'type' => Optional[String]
+	//                 ),
+	//                 Parameter(
+	//                   'name' => 'key_name',
+	//                   'type' => String
+	//                 ),
+	//                 Parameter(
+	//                   'name' => 'tags',
+	//                   'type' => Hash[String, String]
+	//                 )],
+	//               'output' => [
+	//                 Parameter(
+	//                   'name' => 'key',
+	//                   'type' => Optional[String],
+	//                   'value' => 'instance_id'
+	//                 ),
+	//                 Parameter(
+	//                   'name' => 'value',
+	//                   'type' => Tuple[Optional[String], Optional[String]],
+	//                   'value' => ['public_ip', 'private_ip']
+	//                 )],
+	//               'resource_type' => Lyra::Aws::Instance,
+	//               'style' => 'resource'
+	//             }
+	//           ),
+	//           'style' => 'iterator'
+	//         }
+	//       ),
+	//       Service::Definition(
+	//         'identifier' => TypedName(
+	//           'namespace' => 'definition',
+	//           'name' => 'attach::gw'
+	//         ),
+	//         'serviceId' => TypedName(
+	//           'namespace' => 'service',
+	//           'name' => 'Yaml::Test'
+	//         ),
+	//         'properties' => {
+	//           'input' => [
+	//             Parameter(
+	//               'name' => 'region',
+	//               'type' => String
+	//             ),
+	//             Parameter(
+	//               'name' => 'tags',
+	//               'type' => Hash[String, String]
+	//             )],
+	//           'output' => [
+	//             Parameter(
+	//               'name' => 'internet_gateway_id',
+	//               'type' => Optional[String]
+	//             )],
+	//           'resource_type' => Lyra::Aws::InternetGateway,
+	//           'style' => 'resource'
+	//         }
+	//       )],
+	//     'style' => 'workflow'
+	//   }
+	// )
+	// Lyra::Aws::Vpc(
+	//   'ensure' => 'present',
+	//   'region' => 'us-west',
+	//   'tags' => {
+	//     'a' => 'av',
+	//     'b' => 'bv'
+	//   },
+	//   'cidr_block' => '192.168.0.0/16',
+	//   'enable_dns_hostnames' => true,
+	//   'enable_dns_support' => true
+	// )
+}

--- a/yaml/issues.go
+++ b/yaml/issues.go
@@ -1,0 +1,17 @@
+package yaml
+
+import "github.com/lyraproj/issue/issue"
+
+const (
+	WF_BAD_PARAMETER       = `WF_BAD_PARAMETER`
+	WF_FIELD_TYPE_MISMATCH = `WF_FIELD_TYPE_MISMATCH`
+	WF_NOT_ONE_DEFINITION  = `WF_NOT_ONE_DEFINITION`
+	WF_NOT_ACTIVITY        = `WF_NOT_ACTIVITY`
+)
+
+func init() {
+	issue.Hard2(WF_FIELD_TYPE_MISMATCH, `%{activity}: expected %{field} to be a %{expected}, got %{actual}`, issue.HF{`activity`: issue.Label})
+	issue.Hard2(WF_BAD_PARAMETER, `%{activity}: element %{name} is not a valid %{parameter_type} parameter`, issue.HF{`activity`: issue.Label})
+	issue.Hard(WF_NOT_ONE_DEFINITION, `expected exactly one top level key (the activity name)`)
+	issue.Hard(WF_NOT_ACTIVITY, `activity hash must contain workflow "activities" or a resource "state"`)
+}

--- a/yaml/state.go
+++ b/yaml/state.go
@@ -1,0 +1,32 @@
+package yaml
+
+import (
+	"github.com/lyraproj/puppet-evaluator/eval"
+	"github.com/lyraproj/puppet-evaluator/types"
+	"github.com/lyraproj/servicesdk/wfapi"
+)
+
+type state struct {
+	ctx             eval.Context
+	stateType       eval.ObjectType
+	unresolvedState eval.OrderedMap
+}
+
+func (r *state) Type() eval.ObjectType {
+	return r.stateType
+}
+
+func (r *state) State() interface{} {
+	return r.unresolvedState
+}
+
+func ResolveState(ctx eval.Context, state wfapi.State, input eval.OrderedMap) eval.PuppetObject {
+	return ctx.Scope().WithLocalScope(func() (v eval.Value) {
+		scope := ctx.Scope()
+		input.EachPair(func(k, v eval.Value) {
+			scope.Set(k.String(), v)
+		})
+		resolvedState := types.ResolveDeferred(ctx, state.State().(eval.OrderedMap))
+		return eval.New(ctx, state.Type(), resolvedState).(eval.PuppetObject)
+	}).(eval.PuppetObject)
+}

--- a/yaml/testdata/attach.yaml
+++ b/yaml/testdata/attach.yaml
@@ -1,0 +1,63 @@
+ attach:
+   typespace: lyra::aws
+   input:
+     region:
+       type: String
+       lookup: aws.region
+     tags:
+       type: Hash[String,String]
+       lookup: aws.tags
+     key_name:
+       type: String
+       lookup: aws.keyname
+     ec2_cnt:
+       type: Integer
+       lookup: aws.instance.count
+   output:
+     vpc_id: String
+     subnet_id: String
+     internet_gateway_id: String
+     nodes: Hash[String,Struct[public_ip=>String,private_ip=>String]]
+   activities:
+     vpc:
+       output: vpc_id
+       state:
+         ensure              : present
+         region              : $region
+         cidr_block          : 192.168.0.0/16
+         tags                : $tags
+         enable_dns_hostnames: true
+         enable_dns_support  : true
+     subnet:
+       output: subnet_id
+       state:
+         ensure                 : present
+         region                 : $region
+         vpc_id                 : $vpc_id
+         cidr_block             : 192.168.1.0/24
+         tags                   : $tags
+         map_public_ip_on_launch: true
+     instance:
+       output:
+         key: instance_id
+         value: [public_ip, private_ip]
+       iteration:
+         name:     nodes
+         function: times
+         over:     ec2_cnt
+         vars:     i
+       state:
+         region       : $region
+         ensure       : present
+         instance_id  : $i
+         image_id     : ami-f90a4880
+         instance_type: t2.nano
+         key_name     : $key_name
+         tags         : $tags
+     gw:
+       type: Lyra::Aws::InternetGateway
+       output: internet_gateway_id
+       state:
+         ensure: present
+         region: $region
+         tags  : $tags

--- a/yaml/testdata/types.pp
+++ b/yaml/testdata/types.pp
@@ -1,0 +1,42 @@
+type Lyra::Aws::Resource = {
+  attributes => {
+    ensure => Enum[absent, present],
+    region => String,
+    tags => Hash[String,String]
+  }
+}
+
+type Lyra::Aws::Vpc = Lyra::Aws::Resource{
+  attributes => {
+    vpc_id => { type => Optional[String], value => 'FAKED_VPC_ID' },
+    cidr_block => String,
+    enable_dns_hostnames => Boolean,
+    enable_dns_support => Boolean
+  }
+}
+
+type Lyra::Aws::Subnet = Lyra::Aws::Resource{
+  attributes => {
+    subnet_id => { type => Optional[String], value => 'FAKED_SUBNET_ID' },
+    vpc_id => String,
+    cidr_block => String,
+    map_public_ip_on_launch => Boolean
+  }
+}
+
+type Lyra::Aws::Instance = Lyra::Aws::Resource{
+  attributes => {
+    instance_id => { type => Optional[String], value => 'FAKED_INSTANCE_ID' },
+    instance_type => String,
+    image_id => String,
+    key_name => String,
+    public_ip => { type => Optional[String], value => 'FAKED_PUBLIC_IP' },
+    private_ip => { type => Optional[String], value => 'FAKED_PRIVATE_IP' },
+  }
+}
+
+type Lyra::Aws::InternetGateway = Lyra::Aws::Resource{
+  attributes => {
+    internet_gateway_id => { type => Optional[String], value => 'FAKED_GATEWAY_ID' }
+  }
+}


### PR DESCRIPTION
This commit contains the bulk of the work for lyraproj/lyra#36. It
adds the functionality needed to parse YAML and transform the resulting
hash into a wfapi.Activity which is then subsequently used by the
ServiceBuilder to create a Definition that describes it.