### PR TITLE
Ensure nested conversion of input even when type doesn't match.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/hashicorp/go-hclog v0.8.0
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/lyraproj/issue v0.0.0-20190329160035-8bc10230f995
-	github.com/lyraproj/pcore v0.0.0-20190405075742-500ef041fe7e
+	github.com/lyraproj/pcore v0.0.0-20190406122651-bf67b7db25c6
 	github.com/lyraproj/puppet-evaluator v0.0.0-20190405111106-3d49d7f99f4f
 	github.com/lyraproj/puppet-parser v0.0.0-20190329160058-fd1d57e87f6d
 	github.com/lyraproj/servicesdk v0.0.0-20190405110630-7e35406a94bd

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/lyraproj/pcore v0.0.0-20190403155521-a72b635b7c05 h1:DHDepxY8viIusn1/
 github.com/lyraproj/pcore v0.0.0-20190403155521-a72b635b7c05/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
 github.com/lyraproj/pcore v0.0.0-20190405075742-500ef041fe7e h1:BpZKLbm6kW3W3+WeCnXkIRaUWpHx7mIFTZq/v8s47Bc=
 github.com/lyraproj/pcore v0.0.0-20190405075742-500ef041fe7e/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
+github.com/lyraproj/pcore v0.0.0-20190406122651-bf67b7db25c6 h1:vENugHAMnNCBqhUl8OMZEonJ4eEgsdP5RU3WiM4PiNI=
+github.com/lyraproj/pcore v0.0.0-20190406122651-bf67b7db25c6/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
 github.com/lyraproj/puppet-evaluator v0.0.0-20190319215018-daa49117e01b h1:tfMDAZWV00pB8cb1dv3hvPoFlLEkJlzn5QZHTK/aDGg=
 github.com/lyraproj/puppet-evaluator v0.0.0-20190319215018-daa49117e01b/go.mod h1:EUN20EdlItpJBeaR7xVGBcOl463bGvW1sP/5exfODzw=
 github.com/lyraproj/puppet-evaluator v0.0.0-20190401140820-ba7b6d02006e h1:TqEn9SUz7YfumudH6XlPKFiKPCVT4IO6vK/bLvw1abY=

--- a/yaml/activity.go
+++ b/yaml/activity.go
@@ -422,6 +422,12 @@ func (a *activity) resolveInputs(v px.Value, at px.Type, input []px.Parameter) (
 				}
 				es = append(es, types.WrapHashEntry(k, av))
 			})
+		} else {
+			et := types.DefaultAnyType()
+			vr.EachPair(func(k, av px.Value) {
+				av, input = a.resolveInputs(av, et, input)
+				es = append(es, types.WrapHashEntry(k, av))
+			})
 		}
 		v = types.WrapHash(es)
 	case px.List:
@@ -441,6 +447,12 @@ func (a *activity) resolveInputs(v px.Value, at px.Type, input []px.Parameter) (
 				} else {
 					ev, input = a.resolveInputs(ev, types.DefaultAnyType(), input)
 				}
+				es[i] = ev
+			})
+		} else {
+			et := types.DefaultAnyType()
+			vr.EachWithIndex(func(ev px.Value, i int) {
+				ev, input = a.resolveInputs(ev, et, input)
 				es[i] = ev
 			})
 		}


### PR DESCRIPTION
An input value that didn't match its type didn't get recursively
converted which resulted in strange errors. This commit ensures that the
conversion always takes place, even if it in some cases must be done
using a default Any type.