### PR TITLE
Validate that typespace and type properties follow naming convention

### DIFF
--- a/puppetwf/activity.go
+++ b/puppetwf/activity.go
@@ -333,6 +333,9 @@ func (a *puppetActivity) getResourceType(c px.Context) px.ObjectType {
 			}
 			if s, ok := tv.(px.StringValue); ok {
 				n = s.String()
+				if !types.TypeNamePattern.MatchString(n) {
+					panic(px.Error(InvalidTypeName, issue.H{`name`: n}))
+				}
 			} else {
 				panic(px.Error(FieldTypeMismatch, issue.H{`field`: `definition`, `expected`: `Variant[String,ObjectType]`, `actual`: tv}))
 			}
@@ -355,6 +358,9 @@ func (a *puppetActivity) getResourceType(c px.Context) px.ObjectType {
 
 func (a *puppetActivity) getTypeSpace() string {
 	if ts, ok := a.getStringProperty(`typespace`); ok {
+		if !types.TypeNamePattern.MatchString(ts) {
+			panic(px.Error(InvalidTypeName, issue.H{`name`: ts}))
+		}
 		return ts
 	}
 	if a.parent != nil {

--- a/puppetwf/issues.go
+++ b/puppetwf/issues.go
@@ -9,6 +9,7 @@ const (
 	NoServerBuilderInContext = `WF_NO_SERVER_BUILDER_IN_CONTEXT`
 	NotActivity              = `WF_NOT_ACTIVITY`
 	InvalidFunction          = `WF_INVALID_FUNCTION`
+	InvalidTypeName          = `WF_INVALID_TYPE_NAME`
 	MissingRequiredFunction  = `WF_MISSING_REQUIRED_FUNCTION`
 )
 
@@ -18,6 +19,7 @@ func init() {
 	issue.Hard(NoDefinition, `expected activity to contain a definition block`)
 	issue.Hard(NoServerBuilderInContext, `no ServerBuilder has been registered with the evaluation context`)
 	issue.Hard(InvalidFunction, `invalid function '%{function}'. Expected one of 'create', 'read', 'update', or 'delete'`)
+	issue.Hard(InvalidTypeName, `invalid type name '%{name}'. A type name must consist of one to many capitalized segments separated with '::'`)
 	issue.Hard(MissingRequiredFunction, `missing required '%{function}'`)
 	issue.Hard2(NotActivity, `block may only contain workflow activities. %{actual} is not supported here`,
 		issue.HF{`actual`: issue.UcAnOrA})

--- a/puppetwf/testdata/aws_example.pp
+++ b/puppetwf/testdata/aws_example.pp
@@ -1,5 +1,5 @@
 workflow aws_example {
-  typespace => 'aws',
+  typespace => 'Aws',
   input => (
     Hash[String,String] $tags = lookup('aws.tags'),
   ),

--- a/yaml/activity.go
+++ b/yaml/activity.go
@@ -473,6 +473,9 @@ func (a *activity) getResourceType(c px.Context) px.ObjectType {
 		}
 		if s, ok := tv.(px.StringValue); ok {
 			n = s.String()
+			if !types.TypeNamePattern.MatchString(n) {
+				panic(px.Error(InvalidTypeName, issue.H{`name`: n}))
+			}
 		} else {
 			panic(px.Error(FieldTypeMismatch, issue.H{`activity`: a, `field`: `definition`, `expected`: `Variant[String,ObjectType]`, `actual`: tv}))
 		}
@@ -496,7 +499,10 @@ func (a *activity) getResourceType(c px.Context) px.ObjectType {
 
 func (a *activity) getTypespace() string {
 	if ts, ok := a.getStringProperty(a.hash, `typespace`); ok {
-		return ts
+		if types.TypeNamePattern.MatchString(ts) {
+			return ts
+		}
+		panic(px.Error(InvalidTypeName, issue.H{`name`: ts}))
 	}
 	if a.parent != nil {
 		return a.parent.getTypespace()

--- a/yaml/issues.go
+++ b/yaml/issues.go
@@ -7,6 +7,7 @@ const (
 	FieldTypeMismatch = `WF_FIELD_TYPE_MISMATCH`
 	NotOneDefinition  = `WF_NOT_ONE_DEFINITION`
 	NotActivity       = `WF_NOT_ACTIVITY`
+	InvalidTypeName   = `WF_INVALID_TYPE_NAME`
 )
 
 func init() {
@@ -14,4 +15,5 @@ func init() {
 	issue.Hard2(BadParameter, `%{activity}: element %{name} is not a valid %{parameterType} parameter`, issue.HF{`activity`: issue.Label})
 	issue.Hard(NotOneDefinition, `expected exactly one top level key (the activity name)`)
 	issue.Hard(NotActivity, `activity hash must contain workflow "activities" or a resource "state"`)
+	issue.Hard(InvalidTypeName, `invalid type name '%{name}'. A type name must consist of one to many capitalized segments separated with '::'`)
 }

--- a/yaml/testdata/aws_vpc.yaml
+++ b/yaml/testdata/aws_vpc.yaml
@@ -1,5 +1,5 @@
 aws_vpc:
-  typespace: aws
+  typespace: Aws
   input:
     tags:
       type: Hash[String,String]


### PR DESCRIPTION
A pcore type name must consist of capitalized segments separated by
a double colon.

Closes lyraproj/lyra#226
