### PR TITLE
Fix bug causing problems with path segments starting with digit

### DIFF
--- a/puppetwf/service.go
+++ b/puppetwf/service.go
@@ -109,7 +109,13 @@ func munged(path string) string {
 			}
 		} else if c == '_' || c >= '0' && c <= '9' || c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' {
 			if ps || pu {
-				c = unicode.ToUpper(c)
+				// First character of the name must be an upper case letter
+				if ps && (c == '_' || c >= '0' && c <= '9') {
+					// Must insert extra character
+					b.WriteRune('X')
+				} else {
+					c = unicode.ToUpper(c)
+				}
 			}
 			b.WriteRune(c)
 			ps = false

--- a/puppetwf/service_test.go
+++ b/puppetwf/service_test.go
@@ -1,0 +1,31 @@
+package puppetwf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_munged_1(t *testing.T) {
+	require.Equal(t, `Foo::X010::Bar`, munged(`/foo/0.1.0/bar`))
+}
+
+func Test_munged_2(t *testing.T) {
+	require.Equal(t, `Foo::VX::Bar`, munged(`/foo/v::x/bar`))
+}
+
+func Test_munged_3(t *testing.T) {
+	require.Equal(t, `Foo::V0::Bar`, munged(`/foo/v::0/bar`))
+}
+
+func Test_munged_4(t *testing.T) {
+	require.Equal(t, `Foo::ABC::Bar`, munged(`/foo/a.b.c/bar`))
+}
+
+func Test_munged_5(t *testing.T) {
+	require.Equal(t, `Foo::Abc::Bar`, munged(`/foo/abc/bar`))
+}
+
+func Test_munged_6(t *testing.T) {
+	require.Equal(t, `A::B::C`, munged(`/a/b/c/`))
+}


### PR DESCRIPTION
This commit ensures that paths containing segments that starts with
a digit gets munged into a correct TypedName.