### PR TITLE
Replace explicit setting of loader with federated loader

### DIFF
--- a/puppetwf/activity_test.go
+++ b/puppetwf/activity_test.go
@@ -22,7 +22,10 @@ import (
 func withSampleService(sf func(pdsl.EvaluationContext, serviceapi.Service)) {
 	puppet.Do(func(ctx pdsl.EvaluationContext) {
 		// Command to start plug-in and read a given manifest
-		os.Chdir(`testdata`)
+		err := os.Chdir(`testdata`)
+		if err != nil {
+			panic(err)
+		}
 		cmd := exec.Command("go", "run", "../../main/main.go", "--debug")
 
 		// Logger that prints JSON on Stderr

--- a/puppetwf/activity_test.go
+++ b/puppetwf/activity_test.go
@@ -22,7 +22,8 @@ import (
 func withSampleService(sf func(pdsl.EvaluationContext, serviceapi.Service)) {
 	puppet.Do(func(ctx pdsl.EvaluationContext) {
 		// Command to start plug-in and read a given manifest
-		cmd := exec.Command("go", "run", "../main/main.go", "--debug")
+		os.Chdir(`testdata`)
+		cmd := exec.Command("go", "run", "../../main/main.go", "--debug")
 
 		// Logger that prints JSON on Stderr
 		logger := hclog.New(&hclog.LoggerOptions{
@@ -65,7 +66,7 @@ func withSampleLocalService(sf func(pdsl.EvaluationContext, serviceapi.Service))
 func TestStep(t *testing.T) {
 	withSampleService(func(ctx pdsl.EvaluationContext, s serviceapi.Service) {
 		s.Metadata(ctx)
-		rs := s.Invoke(ctx, puppetwf.ManifestLoaderID, "loadManifest", types.WrapString("testdata"), types.WrapString("testdata/aws_example.pp")).(serviceapi.Definition)
+		rs := s.Invoke(ctx, puppetwf.ManifestLoaderID, "loadManifest", types.WrapString("testdata"), types.WrapString("aws_example.pp")).(serviceapi.Definition)
 		v := s.Invoke(ctx, rs.Identifier().Name(), "metadata")
 		assert.Implements(t, (*px.List)(nil), v, "metadata type")
 		vl := v.(px.List)
@@ -84,7 +85,7 @@ func TestStep(t *testing.T) {
   ),
   'serviceId' => TypedName(
     'namespace' => 'service',
-    'name' => 'Testdata::Aws_examplePp'
+    'name' => 'Aws_examplePp'
   ),
   'properties' => {
     'parameters' => [
@@ -113,7 +114,7 @@ func TestStep(t *testing.T) {
         ),
         'serviceId' => TypedName(
           'namespace' => 'service',
-          'name' => 'Testdata::Aws_examplePp'
+          'name' => 'Aws_examplePp'
         ),
         'properties' => {
           'parameters' => [
@@ -137,7 +138,7 @@ func TestStep(t *testing.T) {
         ),
         'serviceId' => TypedName(
           'namespace' => 'service',
-          'name' => 'Testdata::Aws_examplePp'
+          'name' => 'Aws_examplePp'
         ),
         'properties' => {
           'parameters' => [


### PR DESCRIPTION
This changes the Puppet and YAML evaluators so that they use the same
setting for the federated loader of types as Lyra does instead of using
a directory that is passed on from Lyra.

Relates to lyraproj/lyra#262