### PR TITLE
Use yaml.v3 parser to get proper line/col in errors

### DIFF
--- a/puppetwf/activity.go
+++ b/puppetwf/activity.go
@@ -401,13 +401,7 @@ func (a *puppetStep) getStringProperty(field string) (string, bool) {
 
 func (a *puppetStep) amendError() {
 	if r := recover(); r != nil {
-		if rx, ok := r.(issue.Reported); ok {
-			// Location and stack included in nested error
-			r = issue.ErrorWithoutStack(wf.StepBuildError, issue.H{`step`: a.Name()}, nil, rx)
-		} else {
-			r = issue.NewNested(wf.StepBuildError, issue.H{`step`: a.Name()}, nil, wf.ToError(r))
-		}
-		panic(r)
+		panic(issue.NewNested(wf.StepBuildError, issue.H{`step`: a.Name()}, nil, wf.ToError(r)))
 	}
 }
 

--- a/yaml/activity.go
+++ b/yaml/activity.go
@@ -17,9 +17,9 @@ import (
 
 type step struct {
 	name   string
-	origin issue.Location
+	origin string
 	parent *step
-	hash   px.OrderedMap
+	hash   *yaml.Value
 	rt     px.ObjectType
 	step   wf.Step
 }
@@ -34,8 +34,8 @@ func CreateStep(c px.Context, file string, content []byte) wf.Step {
 	c.StackPush(loc)
 	defer c.StackPop()
 
-	v := yaml.Unmarshal(c, content)
-	def, ok := v.(px.OrderedMap)
+	v := yaml.UnmarshalWithPositions(c, content)
+	_, ok := v.Value.(px.OrderedMap)
 	if !ok {
 		panic(px.Error(wf.NotStepDefinition, issue.NoArgs))
 	}
@@ -57,7 +57,7 @@ func CreateStep(c px.Context, file string, content []byte) wf.Step {
 		name = path[len(path)-1]
 	}
 	name = name[:len(name)-len(filepath.Ext(name))]
-	a := newStep(name, loc, nil, def)
+	a := newStep(name, file, nil, v)
 	switch a.stepKind() {
 	case kindWorkflow:
 		return wf.NewWorkflow(c, func(wb wf.WorkflowBuilder) {
@@ -78,46 +78,51 @@ func CreateStep(c px.Context, file string, content []byte) wf.Step {
 	}
 }
 
-func newStep(name string, origin issue.Location, parent *step, ex px.OrderedMap) *step {
+func newStep(name, origin string, parent *step, ex *yaml.Value) *step {
 	ca := &step{origin: origin, parent: parent, hash: ex}
 	sgs := strings.Split(name, `::`)
 	ca.name = sgs[len(sgs)-1]
 	return ca
 }
 
-func (a *step) amendError() {
+func (a *step) amendError(v *yaml.Value) {
 	if r := recover(); r != nil {
-		if rx, ok := r.(issue.Reported); ok {
-			// Location and stack included in nested error
-			r = issue.ErrorWithoutStack(wf.StepBuildError, issue.H{`step`: a.Label()}, nil, rx)
-		} else {
-			r = issue.NewNested(wf.StepBuildError, issue.H{`step`: a.Label()}, a.origin, wf.ToError(r))
+		if re, ok := r.(issue.Reported); ok {
+			// Avoid nesting of errors that stem from the same file
+			if loc := re.Location(); loc != nil && loc.File() == a.origin {
+				panic(re)
+			}
 		}
-		panic(r)
+		panic(issue.NewNested(wf.StepBuildError, issue.H{`step`: a.Label()}, a.location(v), wf.ToError(r)))
 	}
 }
 
-func (a *step) Error(code issue.Code, args issue.H) issue.Reported {
-	return px.Error2(a.origin, code, args)
+func (a *step) location(v *yaml.Value) issue.Location {
+	return issue.NewLocation(a.origin, v.Line, v.Column)
+}
+
+func (a *step) Error(v *yaml.Value, code issue.Code, args issue.H) issue.Reported {
+	return px.Error2(a.location(v), code, args)
 }
 
 func (a *step) stepKind() int {
-	m := a.hash
-	if m.IncludesKey2(`steps`) {
-		return kindWorkflow
+	m, ok := a.hash.Value.(px.OrderedMap)
+	if ok {
+		if m.IncludesKey2(`steps`) {
+			return kindWorkflow
+		}
+		if m.IncludesKey2(`each`) || m.IncludesKey2(`eachPair`) || m.IncludesKey2(`times`) || m.IncludesKey2(`range`) {
+			return kindCollect
+		}
+		if m.IncludesKey2(`reference`) {
+			return kindReference
+		}
+		// hash must include exactly one key which is a type name
+		if m.Keys().Select(func(key px.Value) bool { return types.TypeNamePattern.MatchString(key.String()) }).Len() == 1 {
+			return kindResource
+		}
 	}
-	if m.IncludesKey2(`each`) || m.IncludesKey2(`eachPair`) || m.IncludesKey2(`times`) || m.IncludesKey2(`range`) {
-		return kindCollect
-	}
-	if m.IncludesKey2(`reference`) {
-		return kindReference
-	}
-	// hash must include exactly one key which is a type name
-	if m.Keys().Select(func(key px.Value) bool { return types.TypeNamePattern.MatchString(key.String()) }).Len() == 1 {
-		return kindResource
-	}
-
-	panic(a.Error(wf.NotStep, issue.NoArgs))
+	panic(a.Error(a.hash, wf.NotStep, issue.NoArgs))
 }
 
 func (a *step) Step() wf.Step {
@@ -140,23 +145,24 @@ func (a *step) Label() string {
 }
 
 func (a *step) buildStep(builder wf.Builder) {
+	defer a.amendError(a.hash)
 	builder.Name(a.Name())
 	builder.When(a.getWhen())
-	builder.Parameters(a.extractParameters(builder.Context(), a.hash, `parameters`, false)...)
-	builder.Returns(a.extractParameters(builder.Context(), a.hash, `returns`, true)...)
+	builder.Parameters(a.extractParameters(builder.Context(), `parameters`, false)...)
+	builder.Returns(a.extractParameters(builder.Context(), `returns`, true)...)
 }
 
 func (a *step) buildResource(builder wf.ResourceBuilder) {
-	defer a.amendError()
+	defer a.amendError(a.hash)
 
 	c := builder.Context()
 
 	builder.Name(a.Name())
 	builder.When(a.getWhen())
 
-	st, parameters := a.getState(c, a.extractParameters(builder.Context(), a.hash, `parameters`, false))
+	st, parameters := a.getState(c, a.extractParameters(builder.Context(), `parameters`, false))
 	builder.Parameters(parameters...)
-	builder.Returns(a.extractParameters(builder.Context(), a.hash, `returns`, true)...)
+	builder.Returns(a.extractParameters(builder.Context(), `returns`, true)...)
 	builder.State(&state{ctx: c, stateType: a.getResourceType(c), unresolvedState: st})
 
 	if extId, ok := a.getStringProperty(a.hash, `external_id`); ok {
@@ -165,15 +171,15 @@ func (a *step) buildResource(builder wf.ResourceBuilder) {
 }
 
 func (a *step) buildReference(builder wf.ReferenceBuilder) {
-	defer a.amendError()
+	defer a.amendError(a.hash)
 
 	c := builder.Context()
 
 	builder.Name(a.Name())
 	builder.When(a.getWhen())
 
-	builder.Parameters(a.extractParameters(c, a.hash, `parameters`, true)...)
-	builder.Returns(a.extractParameters(c, a.hash, `returns`, true)...)
+	builder.Parameters(a.extractParameters(c, `parameters`, true)...)
+	builder.Returns(a.extractParameters(c, `returns`, true)...)
 
 	// Step will reference a step with the same name by default.
 	reference := a.Name()
@@ -185,27 +191,28 @@ func (a *step) buildReference(builder wf.ReferenceBuilder) {
 
 func (a *step) buildWorkflow(builder wf.WorkflowBuilder) {
 	a.buildStep(builder)
-	de, ok := a.hash.Get4(`steps`)
+	de, ok := getProperty(a.hash, `steps`)
 	if !ok {
 		return
 	}
 
-	block, ok := de.(px.OrderedMap)
+	block, ok := de.Value.(px.OrderedMap)
 	if !ok {
-		panic(a.Error(wf.FieldTypeMismatch, issue.H{`step`: a, `field`: `definition`, `expected`: `CodeBlock`, `actual`: de}))
+		panic(a.Error(de, wf.FieldTypeMismatch, issue.H{`step`: a, `field`: `definition`, `expected`: `CodeBlock`, `actual`: de.Value}))
 	}
 
 	// Block should only contain step expressions or something is wrong.
 	block.EachPair(func(k, v px.Value) {
-		if as, ok := v.(px.OrderedMap); ok {
-			a.workflowStep(builder, k.String(), as)
+		vl := v.(*yaml.Value)
+		if _, ok := vl.Value.(px.OrderedMap); ok {
+			a.workflowStep(builder, k.String(), vl)
 		} else {
-			panic(a.Error(wf.NotStep, issue.H{`actual`: as}))
+			panic(a.Error(vl, wf.NotStep, issue.H{`actual`: vl.Value}))
 		}
 	})
 }
 
-func (a *step) workflowStep(builder wf.ChildBuilder, name string, as px.OrderedMap) {
+func (a *step) workflowStep(builder wf.ChildBuilder, name string, as *yaml.Value) {
 	ac := newStep(name, a.origin, a, as)
 	switch ac.stepKind() {
 	case kindCollect:
@@ -235,35 +242,34 @@ func (a *step) Style() string {
 func (a *step) buildIterator(builder wf.IteratorBuilder) {
 	a.buildStep(builder)
 
-	var v, over px.Value
+	var vl, ol *yaml.Value
 	var ok bool
-	if v, ok = a.hash.Get4(`each`); ok {
+	if vl, ok = getProperty(a.hash, `each`); ok {
 		builder.Style(wf.IterationStyleEach)
-		over = v
-	} else if v, ok = a.hash.Get4(`eachPair`); ok {
+		ol = vl
+	} else if vl, ok = getProperty(a.hash, `eachPair`); ok {
 		builder.Style(wf.IterationStyleEachPair)
-		over = v
-	} else if v, ok = a.hash.Get4(`times`); ok {
+		ol = vl
+	} else if vl, ok = getProperty(a.hash, `times`); ok {
 		builder.Style(wf.IterationStyleTimes)
-		over = v
-	} else if v, ok = a.hash.Get4(`range`); ok {
+		ol = vl
+	} else if vl, ok = getProperty(a.hash, `range`); ok {
 		builder.Style(wf.IterationStyleRange)
-		over = v
+		ol = vl
 	}
-	if v, ok = a.hash.Get4(`into`); ok {
-		builder.Into(v.String())
+	if vl, ok = getProperty(a.hash, `into`); ok {
+		builder.Into(vl.Value.String())
 	}
-	over, parameters := a.resolveParameters(over, types.DefaultAnyType(), []serviceapi.Parameter{})
+	over, parameters := a.resolveParameters(ol, types.DefaultAnyType(), []serviceapi.Parameter{})
 	builder.Over(over)
 	builder.Parameters(parameters...)
-	builder.Variables(a.extractParameters(builder.Context(), a.hash, `as`, false)...)
+	builder.Variables(a.extractParameters(builder.Context(), `as`, false)...)
 
-	if v, ok = a.hash.Get4(`step`); ok {
-		var step px.OrderedMap
-		if step, ok = v.(px.OrderedMap); ok {
-			a.workflowStep(builder, a.Name(), step)
+	if vl, ok = getProperty(a.hash, `step`); ok {
+		if _, ok = vl.Value.(px.OrderedMap); ok {
+			a.workflowStep(builder, a.Name(), vl)
 		} else {
-			panic(a.Error(wf.NotStep, issue.H{`actual`: v.PType()}))
+			panic(a.Error(vl, wf.NotStep, issue.H{`actual`: vl.Value.PType()}))
 		}
 	}
 }
@@ -275,56 +281,55 @@ func (a *step) getWhen() string {
 	return ``
 }
 
-func (a *step) extractParameters(c px.Context, props px.OrderedMap, field string, aliased bool) []serviceapi.Parameter {
-	if props == nil {
-		return []serviceapi.Parameter{}
-	}
-
-	v, ok := props.Get4(field)
+func (a *step) extractParameters(c px.Context, field string, aliased bool) []serviceapi.Parameter {
+	vl, ok := getProperty(a.hash, field)
 	if !ok {
 		return []serviceapi.Parameter{}
 	}
+	v := vl.Value
 
 	if ph, ok := v.(px.OrderedMap); ok {
 		params := make([]serviceapi.Parameter, 0, ph.Len())
 		ph.EachPair(func(k, v px.Value) {
-			params = append(params, a.makeParameter(c, field, k, v, aliased))
+			params = append(params, a.makeParameter(c, field, k.(*yaml.Value), v.(*yaml.Value), aliased))
 		})
 		return params
 	}
 
 	if _, ok := v.(px.StringValue); ok {
 		// Allow single name as a convenience
-		v = types.WrapValues([]px.Value{v})
+		v = types.WrapValues([]px.Value{vl})
 	}
 
 	if pa, ok := v.(*types.Array); ok {
 		// List of names.
 		params := make([]serviceapi.Parameter, pa.Len())
 		pa.EachWithIndex(func(e px.Value, i int) {
-			if ne, ok := e.(px.StringValue); ok {
+			el := e.(*yaml.Value)
+			if ne, ok := el.Value.(px.StringValue); ok {
 				n := ne.String()
 				if aliased && a.stepKind() == kindResource {
 					// Names must match attribute names
-					params[i] = serviceapi.NewParameter(n, ``, a.attributeType(c, n), nil)
+					params[i] = serviceapi.NewParameter(n, ``, a.attributeType(c, n, el), nil)
 				} else {
 					params[i] = serviceapi.NewParameter(n, ``, types.DefaultAnyType(), nil)
 				}
 			} else {
-				panic(a.Error(wf.BadParameter, issue.H{`step`: a, `name`: e, `parameterType`: field}))
+				panic(a.Error(el, wf.BadParameter, issue.H{`step`: a, `name`: e, `parameterType`: field}))
 			}
 		})
 		return params
 	}
-	panic(a.Error(wf.FieldTypeMismatch, issue.H{`step`: a, `field`: field, `expected`: `Hash`, `actual`: v.PType()}))
+	panic(a.Error(vl, wf.FieldTypeMismatch, issue.H{`step`: a, `field`: field, `expected`: `Hash`, `actual`: v.PType()}))
 }
 
 var varNamePattern = regexp.MustCompile(`\A[a-z]\w*(?:\.[a-z]\w*)*\z`)
 
-func (a *step) makeParameter(c px.Context, field string, k, v px.Value, aliased bool) (param serviceapi.Parameter) {
+func (a *step) makeParameter(c px.Context, field string, kl, vl *yaml.Value, aliased bool) (param serviceapi.Parameter) {
+	k := kl.Value
 	if n, ok := k.(px.StringValue); ok {
 		name := n.String()
-		switch v := v.(type) {
+		switch v := vl.Value.(type) {
 		case px.Parameter:
 			var val px.Value
 			if v.HasValue() {
@@ -341,7 +346,7 @@ func (a *step) makeParameter(c px.Context, field string, k, v px.Value, aliased 
 				if aliased && len(s) > 0 && varNamePattern.MatchString(s) {
 					if a.stepKind() == kindResource {
 						// Alias declaration
-						param = serviceapi.NewParameter(name, s, a.attributeType(c, s), nil)
+						param = serviceapi.NewParameter(name, s, a.attributeType(c, s, vl), nil)
 					} else if a.stepKind() == kindReference {
 						param = serviceapi.NewParameter(name, s, types.DefaultAnyType(), nil)
 					}
@@ -349,7 +354,7 @@ func (a *step) makeParameter(c px.Context, field string, k, v px.Value, aliased 
 			}
 		case px.OrderedMap:
 			var tp px.Type
-			if tn, ok := a.getStringProperty(v, `type`); ok {
+			if tn, ok := a.getStringProperty(vl, `type`); ok {
 				tp = c.ParseType(tn)
 			}
 
@@ -385,7 +390,7 @@ func (a *step) makeParameter(c px.Context, field string, k, v px.Value, aliased 
 		}
 	}
 	if param == nil {
-		panic(a.Error(wf.BadParameter, issue.H{`step`: a, `name`: k, `parameterType`: field}))
+		panic(a.Error(vl, wf.BadParameter, issue.H{`step`: a, `name`: k, `parameterType`: field}))
 	}
 	return
 }
@@ -421,40 +426,44 @@ func getAttributeType(tp px.TypeWithCallableMembers, name string) (px.Type, bool
 	return nil, false
 }
 
-func (a *step) attributeType(c px.Context, name string) px.Type {
+func (a *step) attributeType(c px.Context, name string, k *yaml.Value) px.Type {
 	tp := a.getResourceType(c)
 	if at, ok := getAttributeType(tp, name); ok {
 		return at
 	}
-	panic(a.Error(px.AttributeNotFound, issue.H{`type`: tp, `name`: name}))
+	panic(a.Error(k, px.AttributeNotFound, issue.H{`type`: tp, `name`: name}))
 }
 
-func (a *step) getTypeName() string {
-	keys := a.hash.Keys().Select(func(key px.Value) bool { return types.TypeNamePattern.MatchString(key.String()) })
+func (a *step) getTypeName() *yaml.Value {
+	keys := a.hash.Value.(px.OrderedMap).Keys().Select(func(key px.Value) bool {
+		return types.TypeNamePattern.MatchString(key.(*yaml.Value).Value.String())
+	})
 	if keys.Len() == 1 {
-		return keys.At(0).String()
+		return keys.At(0).(*yaml.Value)
 	}
 	// This should never happen since the step is identified by the presence of a unique type key.
 	panic(fmt.Errorf(`step has no type name key`))
 }
 
 func (a *step) getState(c px.Context, parameters []serviceapi.Parameter) (px.OrderedMap, []serviceapi.Parameter) {
-	de, ok := a.hash.Get4(a.getTypeName())
+	tn := a.getTypeName()
+	de, ok := getProperty(a.hash, tn.Value.String())
 	if !ok {
 		return px.EmptyMap, []serviceapi.Parameter{}
 	}
 
-	if hash, ok := de.(px.OrderedMap); ok {
+	if hash, ok := de.Value.(px.OrderedMap); ok {
 		// Ensure that hash conforms to init of type with respect to attribute names
 		// and transform all variable references to Deferred expressions
 		es := make([]*types.HashEntry, 0, hash.Len())
 		if hash.AllPairs(func(k, v px.Value) bool {
-			if sv, ok := k.(px.StringValue); ok {
+			kl := k.(*yaml.Value)
+			if sv, ok := kl.Unwrap().(px.StringValue); ok {
 				s := sv.String()
 				if varNamePattern.MatchString(s) {
-					at := a.attributeType(c, s)
-					v, parameters = a.resolveParameters(v, at, parameters)
-					es = append(es, types.WrapHashEntry(k, v))
+					at := a.attributeType(c, s, kl)
+					v, parameters = a.resolveParameters(v.(*yaml.Value), at, parameters)
+					es = append(es, types.WrapHashEntry(sv, v))
 					return true
 				}
 			}
@@ -463,7 +472,7 @@ func (a *step) getState(c px.Context, parameters []serviceapi.Parameter) (px.Ord
 			return types.WrapHash(es), parameters
 		}
 	}
-	panic(a.Error(wf.FieldTypeMismatch, issue.H{`step`: a, `field`: `definition`, `expected`: `Hash`, `actual`: de}))
+	panic(a.Error(de, wf.FieldTypeMismatch, issue.H{`step`: a, `field`: `definition`, `expected`: `Hash`, `actual`: de.Value}))
 }
 
 func stripOptional(t px.Type) px.Type {
@@ -473,9 +482,11 @@ func stripOptional(t px.Type) px.Type {
 	return t
 }
 
-func (a *step) resolveParameters(v px.Value, at px.Type, parameters []serviceapi.Parameter) (px.Value, []serviceapi.Parameter) {
-	switch vr := v.(type) {
+func (a *step) resolveParameters(vl *yaml.Value, at px.Type, parameters []serviceapi.Parameter) (px.Value, []serviceapi.Parameter) {
+	var v px.Value
+	switch vr := vl.Value.(type) {
 	case px.StringValue:
+		v = vr
 		s := vr.String()
 		if len(s) > 1 && s[0] == '$' {
 			vn := s[1:]
@@ -502,35 +513,43 @@ func (a *step) resolveParameters(v px.Value, at px.Type, parameters []serviceapi
 		es := make([]*types.HashEntry, 0, vr.Len())
 		nta := stripOptional(at)
 		if ot, ok := nta.(px.TypeWithCallableMembers); ok {
-			vr.EachPair(func(k, av px.Value) {
-				if at, ok := getAttributeType(ot, k.String()); ok {
-					av, parameters = a.resolveParameters(av, at, parameters)
+			vr.EachPair(func(kv, av px.Value) {
+				kv = kv.(*yaml.Value).Unwrap()
+				al := av.(*yaml.Value)
+				if at, ok := getAttributeType(ot, kv.String()); ok {
+					av, parameters = a.resolveParameters(al, at, parameters)
 				} else {
-					av, parameters = a.resolveParameters(av, types.DefaultAnyType(), parameters)
+					av, parameters = a.resolveParameters(al, types.DefaultAnyType(), parameters)
 				}
-				es = append(es, types.WrapHashEntry(k, av))
+				es = append(es, types.WrapHashEntry(kv, av))
 			})
 		} else if ht, ok := nta.(*types.HashType); ok {
 			et := ht.ValueType()
-			vr.EachPair(func(k, av px.Value) {
-				av, parameters = a.resolveParameters(av, et, parameters)
-				es = append(es, types.WrapHashEntry(k, av))
+			vr.EachPair(func(kv, av px.Value) {
+				kv = kv.(*yaml.Value).Unwrap()
+				al := av.(*yaml.Value)
+				av, parameters = a.resolveParameters(al, et, parameters)
+				es = append(es, types.WrapHashEntry(kv, av))
 			})
 		} else if st, ok := nta.(*types.StructType); ok {
 			hm := st.HashedMembers()
-			vr.EachPair(func(k, av px.Value) {
-				if m, ok := hm[k.String()]; ok {
-					av, parameters = a.resolveParameters(av, m.Value(), parameters)
+			vr.EachPair(func(kv, av px.Value) {
+				kv = kv.(*yaml.Value).Unwrap()
+				al := av.(*yaml.Value)
+				if m, ok := hm[kv.String()]; ok {
+					av, parameters = a.resolveParameters(al, m.Value(), parameters)
 				} else {
-					av, parameters = a.resolveParameters(av, types.DefaultAnyType(), parameters)
+					av, parameters = a.resolveParameters(al, types.DefaultAnyType(), parameters)
 				}
-				es = append(es, types.WrapHashEntry(k, av))
+				es = append(es, types.WrapHashEntry(kv, av))
 			})
 		} else {
 			et := types.DefaultAnyType()
-			vr.EachPair(func(k, av px.Value) {
-				av, parameters = a.resolveParameters(av, et, parameters)
-				es = append(es, types.WrapHashEntry(k, av))
+			vr.EachPair(func(kv, av px.Value) {
+				kv = kv.(*yaml.Value).Unwrap()
+				al := av.(*yaml.Value)
+				av, parameters = a.resolveParameters(al, et, parameters)
+				es = append(es, types.WrapHashEntry(kv, av))
 			})
 		}
 		v = types.WrapHash(es)
@@ -540,27 +559,29 @@ func (a *step) resolveParameters(v px.Value, at px.Type, parameters []serviceapi
 		if st, ok := nta.(*types.ArrayType); ok {
 			et := st.ElementType()
 			vr.EachWithIndex(func(ev px.Value, i int) {
-				ev, parameters = a.resolveParameters(ev, et, parameters)
-				es[i] = ev
+				es[i], parameters = a.resolveParameters(ev.(*yaml.Value), et, parameters)
 			})
 		} else if tt, ok := nta.(*types.TupleType); ok {
 			ts := tt.Types()
 			vr.EachWithIndex(func(ev px.Value, i int) {
+				el := ev.(*yaml.Value)
 				if i < len(ts) {
-					ev, parameters = a.resolveParameters(ev, ts[i], parameters)
+					ev, parameters = a.resolveParameters(el, ts[i], parameters)
 				} else {
-					ev, parameters = a.resolveParameters(ev, types.DefaultAnyType(), parameters)
+					ev, parameters = a.resolveParameters(el, types.DefaultAnyType(), parameters)
 				}
 				es[i] = ev
 			})
 		} else {
 			et := types.DefaultAnyType()
 			vr.EachWithIndex(func(ev px.Value, i int) {
-				ev, parameters = a.resolveParameters(ev, et, parameters)
+				ev, parameters = a.resolveParameters(ev.(*yaml.Value), et, parameters)
 				es[i] = ev
 			})
 		}
 		v = types.WrapValues(es)
+	default:
+		v = vr
 	}
 	return v, parameters
 }
@@ -569,25 +590,40 @@ func (a *step) getResourceType(c px.Context) px.ObjectType {
 	if a.rt != nil {
 		return a.rt
 	}
-	n := a.getTypeName()
+	nl := a.getTypeName()
+	defer a.amendError(nl)
+	n := nl.Value.String()
 	if t, ok := px.Load(c, px.NewTypedName(px.NsType, n)); ok {
 		if pt, ok := t.(px.ObjectType); ok {
 			a.rt = pt
 			return pt
 		}
-		panic(a.Error(wf.FieldTypeMismatch, issue.H{`step`: a, `field`: n, `expected`: `ObjectType`, `actual`: t}))
+		panic(a.Error(nl, wf.FieldTypeMismatch, issue.H{`step`: a, `field`: n, `expected`: `ObjectType`, `actual`: t}))
 	}
-	panic(a.Error(px.UnresolvedType, issue.H{`typeString`: n}))
+	panic(a.Error(nl, px.UnresolvedType, issue.H{`typeString`: n}))
 }
 
-func (a *step) getStringProperty(properties px.OrderedMap, field string) (string, bool) {
-	v, ok := properties.Get4(field)
+func (a *step) getStringProperty(properties *yaml.Value, field string) (string, bool) {
+	vl, ok := getProperty(properties, field)
 	if !ok {
 		return ``, false
 	}
+	v := vl.Unwrap()
 
 	if s, ok := v.(px.StringValue); ok {
 		return s.String(), true
 	}
-	panic(a.Error(wf.FieldTypeMismatch, issue.H{`step`: a, `field`: field, `expected`: `String`, `actual`: v.PType()}))
+	panic(a.Error(vl, wf.FieldTypeMismatch, issue.H{`step`: a, `field`: field, `expected`: `String`, `actual`: v.PType()}))
+}
+
+func getProperty(properties *yaml.Value, key string) (*yaml.Value, bool) {
+	if properties != nil {
+		if hash, ok := properties.Value.(px.OrderedMap); ok {
+			var v px.Value
+			if v, ok = hash.Get4(key); ok {
+				return v.(*yaml.Value), true
+			}
+		}
+	}
+	return nil, false
 }

--- a/yaml/testdata/attrfail.yaml
+++ b/yaml/testdata/attrfail.yaml
@@ -1,0 +1,9 @@
+steps:
+  namespace:
+    returns: no_such_attribute
+    Kubernetes::Namespace:
+      namespace_id: "ignore"
+      metadata:
+        name: "terraform-lyra"
+        resource_version: "hi"
+        self_link: "me"

--- a/yaml/testdata/typefail.yaml
+++ b/yaml/testdata/typefail.yaml
@@ -1,0 +1,5 @@
+steps:
+  first:
+    No::Such::Type:
+      one: two
+      three: four


### PR DESCRIPTION
This commit changes the lyra yaml parser to use the yaml.v3 parser
and make use the fact that all nodes now have line and column when
creating errors.